### PR TITLE
Warn when selected export datasets are empty

### DIFF
--- a/src/mi_fitness_mcp/export.py
+++ b/src/mi_fitness_mcp/export.py
@@ -21,6 +21,14 @@ DATASETS: dict[str, tuple[str, str]] = {
 }
 
 
+class ExportResult(list[Path]):
+    """Written export paths plus per-dataset row counts."""
+
+    def __init__(self, paths: list[Path], row_counts: dict[str, int]) -> None:
+        super().__init__(paths)
+        self.row_counts = row_counts
+
+
 def _validate_date_range(start_date: str | None, end_date: str | None) -> None:
     parsed: dict[str, date] = {}
     for name, value in (("start_date", start_date), ("end_date", end_date)):
@@ -87,7 +95,7 @@ def export_database(
     dataset: str | None = None,
     start_date: str | None = None,
     end_date: str | None = None,
-) -> list[Path]:
+) -> ExportResult:
     """Export normalized health records without credentials.
 
     JSON writes one envelope file. CSV writes one file per selected dataset.
@@ -111,6 +119,7 @@ def export_database(
             columns[name], records[name] = _rows(
                 connection, name, start_date=start_date, end_date=end_date
             )
+        row_counts = {name: len(records[name]) for name in selected}
 
     if output_format == "json":
         target = output if output.suffix.lower() == ".json" else output / "mi_fitness_export.json"
@@ -128,7 +137,7 @@ def export_database(
         }
         target.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
         written.append(target)
-        return written
+        return ExportResult(written, row_counts)
 
     output.mkdir(parents=True, exist_ok=True)
     for name in selected:
@@ -138,4 +147,4 @@ def export_database(
             writer.writeheader()
             writer.writerows(records[name])
         written.append(target)
-    return written
+    return ExportResult(written, row_counts)

--- a/src/mi_fitness_mcp/main.py
+++ b/src/mi_fitness_mcp/main.py
@@ -238,6 +238,9 @@ def cmd_export(args):
     print("Export completed")
     for path in written:
         print(f"   {path}")
+    empty_datasets = [name for name, count in written.row_counts.items() if count == 0]
+    if empty_datasets:
+        print(f"Warning: no rows found for selected dataset(s): {', '.join(empty_datasets)}")
 
 
 def main():

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import csv
 import json
 import sqlite3
+from types import SimpleNamespace
 
 import pytest
 
+from mi_fitness_mcp import main as cli
+from mi_fitness_mcp.config import Config
 from mi_fitness_mcp.export import export_database
 from mi_fitness_mcp.storage import Database
 
@@ -62,6 +65,45 @@ def test_csv_export_can_filter_dataset_and_date(tmp_path):
     with written[0].open(encoding="utf-8-sig", newline="") as handle:
         rows = list(csv.DictReader(handle))
     assert rows[0]["weight_kg"] == "73.2"
+
+
+def test_cli_export_warns_for_empty_datasets_without_changing_csv_bytes(
+    monkeypatch, tmp_path, capsys
+):
+    database = _sample_database(tmp_path)
+    baseline = tmp_path / "baseline"
+    cli_output = tmp_path / "cli"
+
+    expected_written = export_database(database, baseline, output_format="csv")
+    monkeypatch.setattr(
+        cli,
+        "load_config",
+        lambda: Config(mode="mi_fitness_cloud", database_path=database),
+    )
+
+    cli.cmd_export(
+        SimpleNamespace(
+            output=cli_output,
+            format="csv",
+            type=None,
+            start_date=None,
+            end_date=None,
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert "Export completed" in output
+    warning_line = next(
+        line for line in output.splitlines() if line.startswith("Warning: no rows found")
+    )
+    assert "sleep" in warning_line
+    assert "heart_rate" in warning_line
+    assert "daily_activity" not in warning_line
+    assert "body_measurements" not in warning_line
+
+    for baseline_path in expected_written:
+        cli_path = cli_output / baseline_path.name
+        assert cli_path.read_bytes() == baseline_path.read_bytes()
 
 
 @pytest.mark.parametrize("invalid_date", ["2026/07/14", "2026-7-14", "not-a-date"])


### PR DESCRIPTION
## Summary

Warn after successful CLI exports when selected datasets have zero rows, without changing the exported JSON/CSV file contents.

Closes #2.

## Validation

- [x] `.venv/bin/python -m pytest tests/test_export.py -q -p no:cacheprovider`
- [x] `.venv/bin/python -m pytest -q -p no:cacheprovider`
- [x] `.venv/bin/python -m ruff check src tests`
- [x] `.venv/bin/python -m compileall -q src tests`
- [x] `git diff --check`

## Data and security

- [x] Fixtures and screenshots use synthetic data only
- [x] No passToken, account ID, database, export, log, or personal health record is included
- [x] Unofficial Xiaomi status and upstream MIT attribution remain intact
- [x] This change does not add a hosted credential proxy or coaching/medical behavior

## Compatibility

Affects the `mi-fitness-bridge export` CLI output only. JSON and CSV export bytes are unchanged; successful empty-dataset exports still exit with status 0.
