### PR TITLE
feat(sleep): add wake-date summary and quality metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - List queries (`query_heart_rate`, `query_spo2`, `query_stress`, `query_abnormal_heart_beat`) push `limit` down to SQL `LIMIT` instead of loading the full table and slicing in Python, and default to a hard cap of 5000 rows when no limit is given.
+- `query_sleep` preserves its raw start-date session list and adds a wake-date main-sleep summary with coverage, missing-date, duplicate-session, nap, score-availability, and invalid-record quality metadata; missing dates are never averaged as zero sleep.
 - Project renamed to 米桥 / Mi Bridge; README GitHub links point to the new `shkyyy18/mi-bridge` repository name, and the trademark disclaimer is a standalone prominent line.
 - The MIT license text of upstream author Aleksej Kubulashvili is preserved in a NOTICE block at the top of `LICENSE`, with the license history (MIT before 2026-08-03, AGPL-3.0-only after) stated in the README.
 - Dropped the unused `click` and `rich` dependencies.

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ mi-fitness-mcp serve
 
 可用的工具包括连接状态、同步、覆盖范围、每日摘要、身体测量、睡眠、运动、心率、血氧（SpO2）和压力查询，以及面向 agent 的 `workout_series` 运动时序工具——按 `max_points` 硬上限自动降采样（固定时间桶均值，SQLite 内聚合），并在响应中如实标注 `downsampled`、`source_points`、`returned_points`、`method`，同时给出全精度统计（avg/min/max/分位数）与心率区间时间。`query_workouts`、`get_daily_summary` 等列表/汇总工具附带 `data_quality`（覆盖天数、缺失指标、最后同步时间）。
 
+`query_sleep` 保留按入睡日期查询的原始缓存会话，并额外返回按本地醒来日期选择的主睡眠汇总和 `data_quality`。同一醒来日有手机、手环等并行记录时，汇总视图只选择最长的有效非午睡会话；`include_naps` 只过滤原始会话列表，质量信息仍会报告该窗口的午睡数量。缺失日期会明确列出，绝不按 0 小时睡眠参与均值；睡眠评分只使用上游实际提供的值，不在本机推算。
+
 客户端接入示例（Claude Code / Codex 等 MCP 客户端的配置 JSON）：
 
 ```json

--- a/src/mi_fitness_mcp/server.py
+++ b/src/mi_fitness_mcp/server.py
@@ -159,7 +159,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="query_sleep",
-            description="Query sleep sessions",
+            description="Query raw sleep sessions plus main-sleep summary and data quality",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -615,8 +615,14 @@ async def _handle_query_sleep(arguments: dict) -> dict:
         end_date=arguments["end_date"],
         include_naps=arguments.get("include_naps", True),
     )
+    summary = query_service.get_sleep_summary(
+        start_date=arguments["start_date"],
+        end_date=arguments["end_date"],
+    )
     return QueryResponse(
-        status="ok", source="cache", data={"sessions": sessions, "count": len(sessions)}
+        status="ok",
+        source="cache",
+        data={"sessions": sessions, "count": len(sessions), **summary},
     ).model_dump()
 
 

--- a/src/mi_fitness_mcp/services/query_service.py
+++ b/src/mi_fitness_mcp/services/query_service.py
@@ -3,7 +3,7 @@
 import math
 import statistics
 from contextlib import suppress
-from datetime import datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from itertools import pairwise
 from typing import Any
 
@@ -21,6 +21,9 @@ HARD_MAX_POINTS = 500
 # heart beat) so an agent calling without an explicit limit cannot pull the
 # entire table into memory; the limit is enforced in SQL, not by slicing.
 DEFAULT_QUERY_LIMIT = 5000
+
+MAX_SLEEP_SESSION_MINUTES = 24 * 60
+MAIN_SLEEP_SELECTION_METHOD = "longest_valid_non_nap_per_wake_date_v1"
 
 
 class QueryService:
@@ -177,30 +180,210 @@ class QueryService:
         sessions = []
         for record in records:
             # 不包含小睡时跳过 nap 记录
-            if not include_naps and record.get("is_nap"):
+            if not include_naps and self._sleep_value_is_true(record.get("is_nap")):
                 continue
 
-            session = {
-                "sleep_id": record["sleep_id"],
-                "start_at": record["start_at"],
-                "end_at": record["end_at"],
-                "duration_minutes": record["duration_minutes"],
-                "time_asleep_minutes": record["time_asleep_minutes"],
-                "time_awake_minutes": record["time_awake_minutes"],
-                "sleep_score": record.get("sleep_score"),
-                "is_nap": record.get("is_nap", False),
-            }
-
-            # 如有睡眠阶段信息则解析
-            if record.get("stages"):
-                import json
-
-                with suppress(json.JSONDecodeError):
-                    session["stages"] = json.loads(record["stages"])
-
-            sessions.append(session)
+            sessions.append(self._sleep_session_payload(record))
 
         return sessions
+
+    @staticmethod
+    def _sleep_value_is_true(value: Any) -> bool:
+        return value is True or str(value).lower() in {"1", "true", "yes"}
+
+    @staticmethod
+    def _sleep_datetime(value: Any) -> datetime | None:
+        if isinstance(value, datetime):
+            return value
+        if not value:
+            return None
+        try:
+            return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+
+    @classmethod
+    def _sleep_session_payload(cls, record: dict[str, Any]) -> dict[str, Any]:
+        session = {
+            "sleep_id": record["sleep_id"],
+            "start_at": record["start_at"],
+            "end_at": record["end_at"],
+            "duration_minutes": record["duration_minutes"],
+            "time_asleep_minutes": record["time_asleep_minutes"],
+            "time_awake_minutes": record["time_awake_minutes"],
+            "sleep_score": record.get("sleep_score"),
+            "is_nap": record.get("is_nap", False),
+        }
+
+        if record.get("stages"):
+            import json
+
+            with suppress(json.JSONDecodeError):
+                session["stages"] = json.loads(record["stages"])
+        return session
+
+    @classmethod
+    def _valid_sleep_record(cls, record: dict[str, Any]) -> bool:
+        start_at = cls._sleep_datetime(record.get("start_at"))
+        end_at = cls._sleep_datetime(record.get("end_at"))
+        try:
+            duration = int(record.get("duration_minutes"))
+            asleep = int(record.get("time_asleep_minutes"))
+            awake = int(record.get("time_awake_minutes"))
+        except (TypeError, ValueError):
+            return False
+        try:
+            valid_time_order = end_at is not None and start_at is not None and end_at > start_at
+        except TypeError:
+            valid_time_order = False
+        return (
+            start_at is not None
+            and end_at is not None
+            and valid_time_order
+            and 0 < duration <= MAX_SLEEP_SESSION_MINUTES
+            and 0 <= asleep <= duration
+            and 0 <= awake <= duration
+            and asleep + awake <= duration
+        )
+
+    def get_sleep_summary(self, start_date: str, end_date: str) -> dict[str, Any]:
+        """Return an agent-safe main-sleep view without rewriting cached sessions.
+
+        The cache can contain parallel phone and wearable sessions for the same
+        local wake date.  Raw sessions remain available through
+        :meth:`get_sleep_sessions`; this summary selects one deterministic main
+        session per date and reports coverage instead of treating missing dates
+        as zero-duration sleep.
+        """
+        window_start = date.fromisoformat(start_date)
+        window_end = date.fromisoformat(end_date)
+        if window_start > window_end:
+            raise ValueError("start_date must not be after end_date")
+
+        normalized_start = window_start.isoformat()
+        normalized_end = window_end.isoformat()
+        records = self.db.query_sleep_sessions_by_end_date(
+            self.user_id, normalized_start, normalized_end
+        )
+        valid_main: list[tuple[dict[str, Any], dict[str, Any], datetime, datetime]] = []
+        raw_main_sessions = 0
+        raw_nap_sessions = 0
+        valid_naps = 0
+        invalid_sessions = 0
+        for record in records:
+            is_nap = self._sleep_value_is_true(record.get("is_nap"))
+            if is_nap:
+                raw_nap_sessions += 1
+            else:
+                raw_main_sessions += 1
+            if not self._valid_sleep_record(record):
+                invalid_sessions += 1
+                continue
+            if is_nap:
+                valid_naps += 1
+                continue
+            start_at = self._sleep_datetime(record.get("start_at"))
+            end_at = self._sleep_datetime(record.get("end_at"))
+            assert start_at is not None and end_at is not None
+            valid_main.append((record, self._sleep_session_payload(record), start_at, end_at))
+
+        main_by_day: dict[
+            str,
+            tuple[tuple[int, float, str, str, str], dict[str, Any], dict[str, Any]],
+        ] = {}
+        for record, session, _start_at, end_at in valid_main:
+            day = end_at.date().isoformat()
+            comparable_end = end_at if end_at.tzinfo is not None else end_at.replace(tzinfo=UTC)
+            preference = (
+                int(record["duration_minutes"]),
+                comparable_end.timestamp(),
+                str(record.get("source_record_id") or ""),
+                str(record.get("sleep_id") or ""),
+                str(record.get("id") or ""),
+            )
+            existing = main_by_day.get(day)
+            if existing is None or preference > existing[0]:
+                main_by_day[day] = (preference, record, session)
+
+        selected = [main_by_day[day] for day in sorted(main_by_day)]
+        selected_records = [row[1] for row in selected]
+        main_sessions = [row[2] for row in selected]
+        requested_dates = [
+            (window_start + timedelta(days=offset)).isoformat()
+            for offset in range((window_end - window_start).days + 1)
+        ]
+        missing_dates = [day for day in requested_dates if day not in main_by_day]
+        score_values: list[float] = []
+        invalid_sleep_scores = 0
+        for session in main_sessions:
+            raw_score = session.get("sleep_score")
+            if raw_score is None:
+                continue
+            try:
+                score = float(raw_score)
+            except (TypeError, ValueError):
+                invalid_sleep_scores += 1
+                continue
+            if not 0 <= score <= 100:
+                invalid_sleep_scores += 1
+                continue
+            score_values.append(score)
+
+        def metric(values: list[float | int]) -> dict[str, Any]:
+            return {
+                "mean": round(statistics.fmean(values), 2) if values else None,
+                "days_with_value": len(values),
+            }
+
+        requested_days = len(requested_dates)
+        main_sleep_days = len(main_sessions)
+        provenance_missing = sum(
+            record.get("source_record_id") in (None, "") for record in selected_records
+        )
+        quality_status = (
+            "complete"
+            if main_sleep_days == requested_days
+            and invalid_sessions == 0
+            else "partial"
+        )
+        return {
+            "main_sessions": main_sessions,
+            "metrics": {
+                "duration_minutes": metric(
+                    [int(session["duration_minutes"]) for session in main_sessions]
+                ),
+                "time_asleep_minutes": metric(
+                    [int(session["time_asleep_minutes"]) for session in main_sessions]
+                ),
+                "sleep_score": metric(score_values),
+            },
+            "data_quality": {
+                "status": quality_status,
+                "date_basis": "local_end_date",
+                "raw_session_date_basis": "local_start_date",
+                "selection_method": MAIN_SLEEP_SELECTION_METHOD,
+                "requested_days": requested_days,
+                "main_sleep_days": main_sleep_days,
+                "coverage_ratio": round(main_sleep_days / requested_days, 4),
+                "missing_main_sleep_dates": missing_dates,
+                "raw_main_sessions": raw_main_sessions,
+                "valid_main_sessions": len(valid_main),
+                "selected_main_sessions": main_sleep_days,
+                "suppressed_parallel_main_sessions": len(valid_main) - main_sleep_days,
+                "nap_sessions": valid_naps,
+                "raw_nap_sessions": raw_nap_sessions,
+                "invalid_sessions_excluded": invalid_sessions,
+                "invalid_sleep_scores_excluded": invalid_sleep_scores,
+                "sleep_score_days": len(score_values),
+                "sleep_score_coverage_ratio": (
+                    round(len(score_values) / main_sleep_days, 4) if main_sleep_days else 0.0
+                ),
+                "provenance_missing_count": provenance_missing,
+                "mean_basis": "selected_main_sessions_only",
+                "sleep_score_basis": "upstream_values_only_no_local_estimation",
+                "missing_days_treated_as_zero": False,
+            },
+        }
 
     def get_workouts(
         self,

--- a/src/mi_fitness_mcp/storage/__init__.py
+++ b/src/mi_fitness_mcp/storage/__init__.py
@@ -754,6 +754,25 @@ class Database:
             ).fetchall()
             return [dict(row) for row in rows]
 
+    def query_sleep_sessions_by_end_date(
+        self,
+        user_id: str,
+        start_date: str,
+        end_date: str,
+    ) -> list[dict[str, Any]]:
+        """Query sleep sessions by the local date on which they ended."""
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT * FROM sleep_sessions
+                WHERE user_id = ?
+                AND substr(end_at, 1, 10) >= ? AND substr(end_at, 1, 10) <= ?
+                ORDER BY end_at, start_at
+                """,
+                (user_id, start_date, end_date),
+            ).fetchall()
+            return [dict(row) for row in rows]
+
     def query_workouts(
         self,
         user_id: str,

--- a/tests/test_sleep_query_summary.py
+++ b/tests/test_sleep_query_summary.py
@@ -1,0 +1,237 @@
+"""Synthetic coverage for query_sleep's main-sleep summary contract."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from mi_fitness_mcp import server
+from mi_fitness_mcp.models import SleepSession
+from mi_fitness_mcp.services.query_service import QueryService
+from mi_fitness_mcp.storage import Database
+
+USER_ID = "synthetic-sleep-user"
+TZ = timezone(timedelta(hours=8))
+BASE = {
+    "provider": "mi_fitness",
+    "source_type": "cloud_session",
+    "user_id": USER_ID,
+}
+
+
+@pytest.fixture
+def db(tmp_path):
+    return Database(tmp_path / "sleep-summary.db")
+
+
+@pytest.fixture
+def service(db):
+    return QueryService(db, USER_ID)
+
+
+def _insert_sleep(
+    db: Database,
+    sleep_id: str,
+    start_at: datetime,
+    duration: int,
+    *,
+    asleep: int | None = None,
+    awake: int = 0,
+    score: int | None = None,
+    is_nap: bool = False,
+    source_record_id: str | None = "synthetic-source",
+) -> None:
+    db.insert_sleep_session(
+        SleepSession(
+            id=f"row-{sleep_id}",
+            source_record_id=source_record_id,
+            sleep_id=sleep_id,
+            start_at=start_at,
+            end_at=start_at + timedelta(minutes=duration),
+            duration_minutes=duration,
+            time_asleep_minutes=duration if asleep is None else asleep,
+            time_awake_minutes=awake,
+            sleep_score=score,
+            is_nap=is_nap,
+            **BASE,
+        )
+    )
+
+
+def test_summary_selects_longest_main_sleep_and_preserves_raw_sessions(db, service):
+    day_one = datetime(2026, 8, 24, 0, 30, tzinfo=TZ)
+    day_two = datetime(2026, 8, 25, 23, 15, tzinfo=TZ)
+    _insert_sleep(db, "parallel-short", day_one, 420, asleep=400, awake=20, score=78)
+    _insert_sleep(db, "parallel-long", day_one, 450, asleep=430, awake=20, score=82)
+    _insert_sleep(db, "main-day-two", day_two, 480, asleep=460, awake=20, score=None)
+    _insert_sleep(db, "nap", day_two.replace(hour=14), 30, is_nap=True)
+
+    sessions = service.get_sleep_sessions("2026-08-24", "2026-08-27")
+    summary = service.get_sleep_summary("2026-08-24", "2026-08-27")
+
+    assert len(sessions) == 4
+    assert [row["sleep_id"] for row in summary["main_sessions"]] == [
+        "parallel-long",
+        "main-day-two",
+    ]
+    assert summary["metrics"] == {
+        "duration_minutes": {"mean": 465.0, "days_with_value": 2},
+        "time_asleep_minutes": {"mean": 445.0, "days_with_value": 2},
+        "sleep_score": {"mean": 82.0, "days_with_value": 1},
+    }
+    assert summary["data_quality"] == {
+        "status": "partial",
+        "date_basis": "local_end_date",
+        "raw_session_date_basis": "local_start_date",
+        "selection_method": "longest_valid_non_nap_per_wake_date_v1",
+        "requested_days": 4,
+        "main_sleep_days": 2,
+        "coverage_ratio": 0.5,
+        "missing_main_sleep_dates": ["2026-08-25", "2026-08-27"],
+        "raw_main_sessions": 3,
+        "valid_main_sessions": 3,
+        "selected_main_sessions": 2,
+        "suppressed_parallel_main_sessions": 1,
+        "nap_sessions": 1,
+        "raw_nap_sessions": 1,
+        "invalid_sessions_excluded": 0,
+        "invalid_sleep_scores_excluded": 0,
+        "sleep_score_days": 1,
+        "sleep_score_coverage_ratio": 0.5,
+        "provenance_missing_count": 0,
+        "mean_basis": "selected_main_sessions_only",
+        "sleep_score_basis": "upstream_values_only_no_local_estimation",
+        "missing_days_treated_as_zero": False,
+    }
+
+
+def test_summary_rejects_invalid_sessions_and_uses_stable_tie_breaker(db, service):
+    start_at = datetime(2026, 8, 24, 1, 0, tzinfo=TZ)
+    _insert_sleep(db, "tie-z", start_at, 450)
+    _insert_sleep(db, "tie-a", start_at, 450)
+    _insert_sleep(db, "zero-duration", start_at + timedelta(days=1), 0)
+    _insert_sleep(
+        db,
+        "asleep-over-duration",
+        start_at + timedelta(days=2),
+        300,
+        asleep=301,
+    )
+
+    summary = service.get_sleep_summary("2026-08-24", "2026-08-26")
+
+    assert [row["sleep_id"] for row in summary["main_sessions"]] == ["tie-z"]
+    assert summary["data_quality"]["invalid_sessions_excluded"] == 2
+    assert summary["data_quality"]["suppressed_parallel_main_sessions"] == 1
+    assert summary["data_quality"]["missing_main_sleep_dates"] == [
+        "2026-08-25",
+        "2026-08-26",
+    ]
+
+
+def test_summary_includes_previous_date_session_by_local_wake_date(db, service):
+    start_at = datetime(2026, 8, 25, 23, 30, tzinfo=TZ)
+    _insert_sleep(db, "cross-midnight", start_at, 465, asleep=450, awake=15, score=87)
+
+    summary = service.get_sleep_summary("2026-08-26", "2026-08-26")
+
+    assert [row["sleep_id"] for row in summary["main_sessions"]] == ["cross-midnight"]
+    assert summary["data_quality"]["main_sleep_days"] == 1
+    assert summary["data_quality"]["missing_main_sleep_dates"] == []
+
+
+def test_sleep_handler_adds_summary_without_changing_session_count(db, service, monkeypatch):
+    start_at = datetime(2026, 8, 24, 1, 0, tzinfo=TZ)
+    _insert_sleep(db, "main", start_at, 450, score=85)
+    _insert_sleep(db, "nap", start_at.replace(hour=14), 30, is_nap=True)
+    monkeypatch.setattr(server, "query_service", service)
+
+    result = asyncio.run(
+        server._handle_query_sleep(
+            {
+                "start_date": "2026-08-24",
+                "end_date": "2026-08-24",
+                "include_naps": False,
+            }
+        )
+    )
+
+    assert result["data"]["count"] == 1
+    assert [row["sleep_id"] for row in result["data"]["sessions"]] == ["main"]
+    assert result["data"]["main_sessions"][0]["sleep_id"] == "main"
+    assert result["data"]["data_quality"]["nap_sessions"] == 1
+    assert result["data"]["data_quality"]["status"] == "complete"
+
+
+def test_handler_keeps_start_date_sessions_separate_from_wake_date_summary(
+    db, service, monkeypatch
+):
+    start_at = datetime(2026, 8, 25, 23, 30, tzinfo=TZ)
+    _insert_sleep(db, "cross-midnight", start_at, 465, asleep=450, awake=15, score=87)
+    monkeypatch.setattr(server, "query_service", service)
+
+    result = asyncio.run(
+        server._handle_query_sleep(
+            {"start_date": "2026-08-26", "end_date": "2026-08-26"}
+        )
+    )
+
+    assert result["data"]["sessions"] == []
+    assert result["data"]["count"] == 0
+    assert [row["sleep_id"] for row in result["data"]["main_sessions"]] == [
+        "cross-midnight"
+    ]
+
+
+def test_complete_coverage_does_not_require_score_or_provenance(db, service):
+    start_at = datetime(2026, 8, 24, 0, 30, tzinfo=TZ)
+    _insert_sleep(db, "main", start_at, 450, score=None, source_record_id=None)
+
+    summary = service.get_sleep_summary("2026-08-24", "2026-08-24")
+
+    assert summary["data_quality"]["status"] == "complete"
+    assert summary["data_quality"]["sleep_score_coverage_ratio"] == 0.0
+    assert summary["data_quality"]["provenance_missing_count"] == 1
+
+
+def test_invalid_sleep_score_is_excluded_without_failing_query(db, service):
+    start_at = datetime(2026, 8, 24, 0, 30, tzinfo=TZ)
+    _insert_sleep(db, "main", start_at, 450, score=85)
+    with db._get_connection() as connection:
+        connection.execute(
+            "UPDATE sleep_sessions SET sleep_score = ? WHERE sleep_id = ?",
+            ("not-a-score", "main"),
+        )
+        connection.commit()
+
+    summary = service.get_sleep_summary("2026-08-24", "2026-08-24")
+
+    assert summary["metrics"]["sleep_score"] == {"mean": None, "days_with_value": 0}
+    assert summary["data_quality"]["invalid_sleep_scores_excluded"] == 1
+
+
+def test_summary_excludes_sleep_that_wakes_after_window(db, service):
+    start_at = datetime(2026, 8, 24, 23, 30, tzinfo=TZ)
+    _insert_sleep(db, "next-day-wake", start_at, 465, score=87)
+
+    summary = service.get_sleep_summary("2026-08-24", "2026-08-24")
+
+    assert summary["main_sessions"] == []
+    assert summary["data_quality"]["missing_main_sleep_dates"] == ["2026-08-24"]
+
+
+def test_raw_session_payload_keeps_existing_is_nap_type(db, service):
+    start_at = datetime(2026, 8, 24, 14, 0, tzinfo=TZ)
+    _insert_sleep(db, "nap", start_at, 30, is_nap=True)
+
+    sessions = service.get_sleep_sessions("2026-08-24", "2026-08-24")
+
+    assert sessions[0]["is_nap"] == 1
+    assert isinstance(sessions[0]["is_nap"], int)
+
+
+def test_summary_rejects_reversed_date_window(service):
+    with pytest.raises(ValueError, match="start_date must not be after end_date"):
+        service.get_sleep_summary("2026-08-25", "2026-08-24")


### PR DESCRIPTION
## Summary

- preserve the existing raw, start-date-based `sessions` list and `count`
- add a deterministic main-sleep view grouped by local wake date
- expose coverage, missing dates, parallel-session suppression, naps, invalid rows, score availability, and provenance quality metadata
- keep sleep score upstream-only; missing days are never averaged as zero sleep

## Why

Overnight sessions cross calendar boundaries, while user-facing daily sleep summaries are associated with the day the session ends. The cache can also contain parallel phone and wearable sessions for one wake date. Returning only the raw session list makes weekly averages easy to miscompute or double count.

This change adds an agent-safe summary without rewriting cached rows or changing the existing raw query behavior.

## Compatibility

- additive MCP response fields only
- no SQLite schema migration
- no adapter, sync, or export behavior changes
- `include_naps` continues to filter only the raw `sessions` list; summary quality still reports naps in the requested wake-date window
- sleep stages remain per-session data; no synthetic weekly stage statistic is introduced
- proprietary Mi Fitness sleep scores are not inferred

## Verification

- `python -m pytest -q -p no:cacheprovider` — 85 passed
- `python -m ruff check src tests` — passed
- `git diff --check` — passed

All fixtures are synthetic; the PR contains no credentials, database rows, exports, logs, screenshots, or personal health data.